### PR TITLE
add test with only optional attendees who are busy

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -385,4 +385,29 @@ public final class FindMeetingQueryTest {
 
     Assert.assertEquals(expected, actual);
   }
+
+  @Test
+  public void onlyOptionalAttendeesBusy() {
+    // No mandatory attendees, just two optional attendees with no gap between in their schedule.
+    // Should output whole day as an option as the optional attendees cannot be accomodated
+    // and the mandatory ones (zero of them) are free all day.
+    //
+    // Events  : |----A----|-----B-----|
+    // Day     : |---------------------|
+    // Options : |---------------------|
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_1100AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_1100AM, TimeRange.END_OF_DAY, false),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList(TimeRange.WHOLE_DAY);
+
+    Assert.assertEquals(expected, actual);
+  }
 }


### PR DESCRIPTION
Returns schedule of all day as it cannot satisfy optional attendees' schedule but satisfy the mandatory attendees (all zero of them).